### PR TITLE
Create Neon Flux Garden SFML demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/build/
+/.vs/
+/.idea/
+*.sln
+*.vcxproj*
+.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.14)
+project(NeonFluxGarden LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(SFML 2.5 COMPONENTS graphics window system REQUIRED)
+
+add_executable(neon_flux_garden src/main.cpp)
+
+target_link_libraries(neon_flux_garden PRIVATE sfml-graphics sfml-window sfml-system)
+
+target_compile_options(neon_flux_garden PRIVATE
+    $<$<CXX_COMPILER_ID:GNU,Clang>:-Wall -Wextra -Wpedantic>
+)
+
+if (MSVC)
+    target_compile_options(neon_flux_garden PRIVATE /W4)
+endif()
+
+add_custom_target(copy_resources ALL
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${CMAKE_SOURCE_DIR}/resources
+            ${CMAKE_BINARY_DIR}/resources)
+
+add_dependencies(neon_flux_garden copy_resources)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,63 @@
-# Excise
-do homework
+# Neon Flux Garden
+
+An interactive, shader-driven particle playground written in modern C++ with SFML. Move your mouse to sculpt neon energy streams, toggle attraction and repulsion, unleash energy bursts, and soak in a kaleidoscopic vortex rendered completely on the GPU.
+
+## Features
+
+- **Dynamic kaleidoscopic shader** backdrop that reacts to time, energy polarity, and mouse position.
+- **GPU-accelerated particle ribbons** with additive blending and persistence trails.
+- **Interactive controls** to toggle turbulence, color cycling, slow-motion, and attraction/repulsion modes.
+- **Energy bursts** spawned from your cursor, letting you paint the scene in realtime.
+- **Portable CMake project** targeting C++17 and SFML 2.5+.
+
+## Controls
+
+| Input            | Action                                   |
+| ---------------- | ---------------------------------------- |
+| Mouse move       | Sculpt the energy field                  |
+| Left mouse       | Emit a burst of particles                |
+| Right mouse      | Toggle attraction / repulsion            |
+| `Space`          | Toggle turbulent vortex forces           |
+| `C`              | Toggle chroma cycling                    |
+| `S`              | Toggle slow-motion                       |
+| `R`              | Reset the particle universe              |
+| `Esc` / window X | Quit the experience                      |
+
+## Build instructions
+
+1. Install the SFML development libraries for your platform (2.5 or newer).
+2. Configure the project with CMake, then build:
+
+   ```bash
+   cmake -B build
+   cmake --build build
+   ```
+
+3. Run the executable (ensure the `resources/` directory sits alongside it):
+
+   ```bash
+   ./build/neon_flux_garden
+   ```
+
+On Windows, use the Visual Studio generator (or `cmake -G "Ninja Multi-Config"`) and launch `neon_flux_garden.exe` from the build output folder.
+
+## Project layout
+
+```
+.
+├── CMakeLists.txt         # Build configuration
+├── resources
+│   └── shaders
+│       └── kaleido.frag   # GLSL fragment shader for the neon background
+├── src
+│   └── main.cpp           # Application entry point and particle playground
+└── README.md              # You are here
+```
+
+## Notes
+
+- The application uses fragment shaders; a GPU supporting GLSL 1.20+ (OpenGL 2.1) is required.
+- The render texture is rebuilt on launch. If you resize the window in code, make sure to recreate the render texture accordingly.
+- If SFML reports that shaders are unavailable, update your graphics drivers or try running on a discrete GPU.
+
+Enjoy sculpting your own neon flux garden!

--- a/resources/shaders/kaleido.frag
+++ b/resources/shaders/kaleido.frag
@@ -1,0 +1,75 @@
+#ifdef GL_ES
+precision mediump float;
+#endif
+
+uniform vec2 u_resolution;
+uniform vec2 u_mouse;
+uniform float u_time;
+uniform float u_energy;
+
+vec2 rotate(vec2 v, float a)
+{
+    float c = cos(a);
+    float s = sin(a);
+    return vec2(c * v.x - s * v.y, s * v.x + c * v.y);
+}
+
+float petal(vec2 uv, float petals, float power)
+{
+    float angle = atan(uv.y, uv.x);
+    float radius = length(uv);
+    float wave = cos(angle * petals) * 0.5 + 0.5;
+    return pow(wave, power) * exp(-radius * 2.0);
+}
+
+float tunnel(vec2 uv)
+{
+    float r = length(uv);
+    return sin(r * 6.0 - u_time * 6.0) * 0.5 + 0.5;
+}
+
+void main()
+{
+    vec2 uv = (gl_FragCoord.xy * 2.0 - u_resolution.xy) / u_resolution.y;
+    vec2 mouseNorm = (u_mouse * 2.0 - u_resolution.xy) / u_resolution.y;
+
+    float mouseInfluence = length(mouseNorm);
+    float energy = mix(-1.0, 1.0, u_energy * 0.5 + 0.5);
+
+    float baseRotation = u_time * 0.25 + mouseInfluence * 2.0;
+    uv = rotate(uv, baseRotation);
+
+    float bloom = 0.0;
+    for (int i = 0; i < 6; ++i)
+    {
+        float petals = 4.0 + float(i) * 1.5 + mouseInfluence * 5.0;
+        float power = 1.5 + sin(u_time + float(i)) * 0.5 + mouseInfluence;
+        bloom += petal(uv, petals, power);
+        uv = rotate(uv, 3.14159 / 6.0);
+    }
+
+    vec2 tunnelUV = rotate(uv, u_time * 0.5);
+    float vortex = tunnel(tunnelUV * (1.5 + mouseInfluence * 0.5));
+
+    float glow = bloom * 0.6 + vortex * 0.4;
+    float pulse = sin(u_time * 3.0 + mouseInfluence * 5.0) * 0.5 + 0.5;
+    float halo = exp(-dot(uv, uv) * 3.0) * (0.5 + pulse * 0.5);
+
+    vec3 baseColor = vec3(0.05, 0.1, 0.2);
+    vec3 neonA = vec3(0.3, 0.7, 1.0);
+    vec3 neonB = vec3(1.0, 0.2, 0.8);
+    vec3 neonC = vec3(0.2, 1.0, 0.5);
+
+    float colorMix = fract(glow * 0.4 + u_time * 0.1 + mouseInfluence * 0.2);
+    vec3 palette = mix(neonA, neonB, smoothstep(0.0, 0.5, colorMix));
+    palette = mix(palette, neonC, smoothstep(0.5, 1.0, colorMix));
+
+    vec3 color = baseColor;
+    color += palette * glow * (0.7 + halo * 0.5);
+    color += vec3(0.1, 0.05, 0.15) * halo * (1.0 + energy * 0.3);
+
+    float vignette = smoothstep(1.2, 0.3, length(uv));
+    color *= vignette;
+
+    gl_FragColor = vec4(color, 1.0);
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,303 @@
+#include <SFML/Graphics.hpp>
+#include <SFML/System.hpp>
+#include <SFML/Window.hpp>
+
+#include <cmath>
+#include <iostream>
+#include <random>
+#include <vector>
+
+namespace
+{
+struct Particle
+{
+    sf::Vector2f position;
+    sf::Vector2f velocity;
+    float life = 0.f;
+    float maxLife = 1.f;
+    float hueOffset = 0.f;
+};
+
+float length(const sf::Vector2f &v)
+{
+    return std::sqrt(v.x * v.x + v.y * v.y);
+}
+
+sf::Vector2f normalize(const sf::Vector2f &v)
+{
+    float len = length(v);
+    if (len == 0.f)
+    {
+        return {0.f, 0.f};
+    }
+    return v / len;
+}
+
+float wrapAngle(float angle)
+{
+    constexpr float twoPi = 6.28318530718f;
+    while (angle < 0.f)
+    {
+        angle += twoPi;
+    }
+    while (angle >= twoPi)
+    {
+        angle -= twoPi;
+    }
+    return angle;
+}
+
+sf::Color hsvToRgb(float h, float s, float v)
+{
+    h = wrapAngle(h) / (2.f * static_cast<float>(M_PI));
+    float c = v * s;
+    float x = c * (1.f - std::fabs(std::fmod(h * 6.f, 2.f) - 1.f));
+    float m = v - c;
+
+    sf::Color color;
+    if (h < 1.f / 6.f)
+        color = sf::Color(static_cast<sf::Uint8>((c + m) * 255), static_cast<sf::Uint8>((x + m) * 255), static_cast<sf::Uint8>(m * 255));
+    else if (h < 2.f / 6.f)
+        color = sf::Color(static_cast<sf::Uint8>((x + m) * 255), static_cast<sf::Uint8>((c + m) * 255), static_cast<sf::Uint8>(m * 255));
+    else if (h < 3.f / 6.f)
+        color = sf::Color(static_cast<sf::Uint8>(m * 255), static_cast<sf::Uint8>((c + m) * 255), static_cast<sf::Uint8>((x + m) * 255));
+    else if (h < 4.f / 6.f)
+        color = sf::Color(static_cast<sf::Uint8>(m * 255), static_cast<sf::Uint8>((x + m) * 255), static_cast<sf::Uint8>((c + m) * 255));
+    else if (h < 5.f / 6.f)
+        color = sf::Color(static_cast<sf::Uint8>((x + m) * 255), static_cast<sf::Uint8>(m * 255), static_cast<sf::Uint8>((c + m) * 255));
+    else
+        color = sf::Color(static_cast<sf::Uint8>((c + m) * 255), static_cast<sf::Uint8>(m * 255), static_cast<sf::Uint8>((x + m) * 255));
+
+    return color;
+}
+
+float pseudoNoise2D(float x, float y)
+{
+    return std::sin(x * 1.7f + y * 2.3f) * 0.5f + std::cos(x * 0.5f - y * 1.9f) * 0.5f;
+}
+
+Particle makeParticle(const sf::Vector2f &center, std::mt19937 &rng, std::uniform_real_distribution<float> &dist)
+{
+    Particle p;
+    float radius = dist(rng) * 200.f + 20.f;
+    float angle = dist(rng) * 2.f * static_cast<float>(M_PI);
+    p.position = center + sf::Vector2f(std::cos(angle), std::sin(angle)) * radius;
+    p.velocity = sf::Vector2f(-std::sin(angle), std::cos(angle)) * (dist(rng) * 120.f + 50.f);
+    p.life = 0.f;
+    p.maxLife = dist(rng) * 6.f + 2.f;
+    p.hueOffset = dist(rng) * 2.f * static_cast<float>(M_PI);
+    return p;
+}
+}
+
+int main()
+{
+    const unsigned int windowWidth = 1280;
+    const unsigned int windowHeight = 720;
+
+    sf::ContextSettings settings;
+    settings.antialiasingLevel = 8;
+
+    sf::RenderWindow window(sf::VideoMode(windowWidth, windowHeight), "Neon Flux Garden", sf::Style::Close, settings);
+    window.setVerticalSyncEnabled(true);
+
+    if (!sf::Shader::isAvailable())
+    {
+        std::cerr << "Shader support not available on this device.\n";
+        return 1;
+    }
+
+    sf::Shader backgroundShader;
+    if (!backgroundShader.loadFromFile("resources/shaders/kaleido.frag", sf::Shader::Fragment))
+    {
+        std::cerr << "Failed to load fragment shader.\n";
+        return 1;
+    }
+
+    std::cout << "\nNeon Flux Garden\n"
+              << "==================\n"
+              << "Controls:\n"
+              << "  Mouse Move : Sculpt the energy field\n"
+              << "  Left Click : Emit an energy burst\n"
+              << "  Right Click: Toggle attraction / repulsion\n"
+              << "  SPACE      : Toggle vortex turbulence\n"
+              << "  C          : Toggle chroma cycling\n"
+              << "  S          : Toggle slow-motion\n"
+              << "  R          : Reset the particle universe\n"
+              << "  ESC        : Quit\n";
+
+    sf::Vector2u renderSize(windowWidth, windowHeight);
+    sf::RenderTexture trailTexture;
+    if (!trailTexture.create(renderSize.x, renderSize.y))
+    {
+        std::cerr << "Failed to create render texture.\n";
+        return 1;
+    }
+    trailTexture.clear(sf::Color::Black);
+
+    sf::RectangleShape fullscreenQuad(sf::Vector2f(static_cast<float>(renderSize.x), static_cast<float>(renderSize.y)));
+
+    std::vector<Particle> particles;
+    particles.reserve(2000);
+    const std::size_t particleCount = 1200;
+
+    std::mt19937 rng(std::random_device{}());
+    std::uniform_real_distribution<float> dist01(0.f, 1.f);
+
+    sf::Vector2f center(renderSize.x / 2.f, renderSize.y / 2.f);
+    for (std::size_t i = 0; i < particleCount; ++i)
+    {
+        particles.push_back(makeParticle(center, rng, dist01));
+    }
+
+    bool chromaCycling = true;
+    bool turbulenceEnabled = true;
+    bool attractMode = true;
+    bool slowMotion = false;
+    float time = 0.f;
+    float chromaTime = 0.f;
+
+    sf::Clock deltaClock;
+    sf::Clock globalClock;
+
+    while (window.isOpen())
+    {
+        sf::Event event;
+        while (window.pollEvent(event))
+        {
+            if (event.type == sf::Event::Closed)
+            {
+                window.close();
+            }
+            if (event.type == sf::Event::KeyPressed)
+            {
+                if (event.key.code == sf::Keyboard::Escape)
+                {
+                    window.close();
+                }
+                else if (event.key.code == sf::Keyboard::C)
+                {
+                    chromaCycling = !chromaCycling;
+                }
+                else if (event.key.code == sf::Keyboard::Space)
+                {
+                    turbulenceEnabled = !turbulenceEnabled;
+                }
+                else if (event.key.code == sf::Keyboard::R)
+                {
+                    particles.clear();
+                    for (std::size_t i = 0; i < particleCount; ++i)
+                    {
+                        particles.push_back(makeParticle(center, rng, dist01));
+                    }
+                    trailTexture.clear(sf::Color::Black);
+                }
+                else if (event.key.code == sf::Keyboard::S)
+                {
+                    slowMotion = !slowMotion;
+                }
+            }
+            if (event.type == sf::Event::MouseButtonPressed)
+            {
+                if (event.mouseButton.button == sf::Mouse::Right)
+                {
+                    attractMode = !attractMode;
+                }
+            }
+        }
+
+        float dt = deltaClock.restart().asSeconds();
+        if (slowMotion)
+        {
+            dt *= 0.25f;
+        }
+        time = globalClock.getElapsedTime().asSeconds();
+        if (chromaCycling)
+        {
+            chromaTime += dt * 0.25f;
+        }
+
+        sf::Vector2i mousePosition = sf::Mouse::getPosition(window);
+        sf::Vector2f mouseFloat(static_cast<float>(mousePosition.x), static_cast<float>(mousePosition.y));
+
+        if (sf::Mouse::isButtonPressed(sf::Mouse::Left))
+        {
+            for (int i = 0; i < 10; ++i)
+            {
+                particles.push_back(makeParticle(mouseFloat, rng, dist01));
+            }
+        }
+
+        if (particles.size() > 5000)
+        {
+            particles.erase(particles.begin(), particles.begin() + (particles.size() - 5000));
+        }
+
+        sf::VertexArray particleVertices(sf::Points, particles.size());
+        for (std::size_t i = 0; i < particles.size(); ++i)
+        {
+            Particle &p = particles[i];
+            p.life += dt;
+            if (p.life > p.maxLife)
+            {
+                p = makeParticle(mouseFloat, rng, dist01);
+                p.life = 0.f;
+            }
+
+            sf::Vector2f direction = mouseFloat - p.position;
+            float distance = length(direction) + 1.f;
+            sf::Vector2f force = normalize(direction) * (120.f / distance);
+            if (!attractMode)
+            {
+                force = -force;
+            }
+
+            if (turbulenceEnabled)
+            {
+                float n = pseudoNoise2D(p.position.x * 0.01f + time * 0.2f, p.position.y * 0.01f - time * 0.2f);
+                sf::Vector2f perpendicular(-force.y, force.x);
+                force += perpendicular * n * 0.5f;
+            }
+
+            p.velocity += force * dt * 60.f;
+            p.velocity *= 0.96f;
+            p.position += p.velocity * dt;
+
+            if (p.position.x < -100.f || p.position.x > windowWidth + 100.f || p.position.y < -100.f || p.position.y > windowHeight + 100.f)
+            {
+                p = makeParticle(mouseFloat, rng, dist01);
+            }
+
+            float hue = p.hueOffset + chromaTime * 2.f;
+            float saturation = 0.9f;
+            float value = 0.9f;
+            sf::Color color = hsvToRgb(hue, saturation, value);
+            float alphaScale = std::max(0.f, 1.f - (p.life / p.maxLife));
+            color.a = static_cast<sf::Uint8>(alphaScale * 255);
+
+            particleVertices[i].position = p.position;
+            particleVertices[i].color = color;
+        }
+
+        sf::RectangleShape fadeRect(sf::Vector2f(static_cast<float>(renderSize.x), static_cast<float>(renderSize.y)));
+        fadeRect.setFillColor(sf::Color(0, 0, 0, slowMotion ? 10 : 35));
+
+        trailTexture.draw(fadeRect, sf::BlendAlpha);
+        trailTexture.draw(particleVertices, sf::BlendAdd);
+        trailTexture.display();
+
+        backgroundShader.setUniform("u_time", time * 0.2f);
+        backgroundShader.setUniform("u_resolution", sf::Vector2f(static_cast<float>(renderSize.x), static_cast<float>(renderSize.y)));
+        backgroundShader.setUniform("u_mouse", mouseFloat);
+        backgroundShader.setUniform("u_energy", attractMode ? 1.f : -1.f);
+
+        window.clear(sf::Color::Black);
+        window.draw(fullscreenQuad, &backgroundShader);
+        sf::Sprite trailSprite(trailTexture.getTexture());
+        trailSprite.setColor(sf::Color(255, 255, 255, 220));
+        window.draw(trailSprite, sf::BlendAdd);
+        window.display();
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a C++17/SFML project scaffold with a configurable CMake build
- implement the Neon Flux Garden interactive particle playground with shader-driven visuals
- provide a kaleidoscopic fragment shader and project documentation, including build and control instructions

## Testing
- `cmake -B build` *(fails: SFML development package not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cffbbfced08320a6b5f15afc493d76